### PR TITLE
Update gen-index.yml

### DIFF
--- a/.github/workflows/gen-index.yml
+++ b/.github/workflows/gen-index.yml
@@ -31,7 +31,6 @@ jobs:
           mkdir out/source/
           ./ClassIsland.PluginIndexGenerator.exe index out/source/index.json -b base.json -t $env:GITHUB_TOKEN
           7z a "./out/index.zip" ./out/source/* -r -mx=9
-          rm -r -Force out/source/
           
       - name: Generate MD5
         run: |


### PR DESCRIPTION
可恶的rm，被我删掉了

This pull request includes a change to the `.github/workflows/gen-index.yml` file to improve the workflow process. The most important change is the removal of a command that deletes the `out/source/` directory after zipping its contents.

Workflow process improvement:

* [`.github/workflows/gen-index.yml`](diffhunk://#diff-f544a512d38680e942d2870b6171c3d8aa8ed4517bf426b8a31985be12874df8L34): Removed the command `rm -r -Force out/source/` to prevent deletion of the `out/source/` directory after creating the zip file.