### PR TITLE
更新 MediaIsland 的描述及 SDK 版本

### DIFF
--- a/index/plugins/bywhite.mediaisland.yml
+++ b/index/plugins/bywhite.mediaisland.yml
@@ -4,11 +4,11 @@
 
 id: bywhite.mediaisland
 name: MediaIsland
-description: 在 ClassIsland 显示 SMTC 媒体信息。
+description: 在主界面显示 Windows SMTC 媒体信息。
 entranceAssembly: "MediaIsland.dll"
 url: https://github.com/bywhite0/MediaIsland
-version: 1.0.0.3
-apiVersion: 1.5.0
+version: 1.0.5.0
+apiVersion: 1.6.0.5
 author: bywhite0
 readme: README.md
 icon: icon.png


### PR DESCRIPTION
通过遥测发现有部分 Linux 用户尝试在 1.7.10x 版本使用 MediaIsland。鉴于本插件目前仅支持 Windows，修改了在插件市场中的描述，避免发生上述情况。~~不是所有人都知道 SMTC 是 Windows App SDK 接口~~

另外更新了插件市场上本插件的 SDK 版本。