### PR TITLE
添加QQListener插件

### DIFF
--- a/index/plugins-v2/QQListener.yml
+++ b/index/plugins-v2/QQListener.yml
@@ -6,8 +6,11 @@
 id: QQListener
 name: QQListener
 description: 监听 Windows 通知中心中的 QQ 消息，并转发为 ClassIsland 提醒。
-entranceAssembly: QQListener.dll
+entranceAssembly: "QQListener.dll"
 url: https://github.com/alright-qwq/QQListener
-version: 0.0.2.0
+version: 0.1.0.0
 apiVersion: 2.0.0.0
 author: alright-qwq
+repoOwner: alright-qwq
+repoName: QQListener
+assetsRoot: master

--- a/index/plugins-v2/QQListener.yml
+++ b/index/plugins-v2/QQListener.yml
@@ -1,0 +1,13 @@
+# nonk8s
+# 插件清单文件使用 YAML 格式存储。
+# YAML 教程：https://www.runoob.com/w3cnote/yaml-intro.html
+# 插件清单格式：https://docs.classisland.tech/zh-cn/latest/dev/plugins/create-project/#%E6%8F%92%E4%BB%B6%E6%B8%85%E5%8D%95%E6%96%87%E4%BB%B6
+
+id: QQListener
+name: QQListener
+description: 监听 Windows 通知中心中的 QQ 消息，并转发为 ClassIsland 提醒。
+entranceAssembly: QQListener.dll
+url: https://github.com/alright-qwq/QQListener
+version: 0.0.2.0
+apiVersion: 2.0.0.0
+author: alright-qwq


### PR DESCRIPTION
一个用于监听 Windows 通知中心中的 QQ 通知，并把新消息转发为 ClassIsland 提醒的插件