### PR TITLE
添加 ConvenientText 插件

### DIFF
--- a/index/plugins-v2/ConvenientText.yml
+++ b/index/plugins-v2/ConvenientText.yml
@@ -3,13 +3,9 @@ name: 便捷文本插件
 description: 桌面悬浮窗快速修改文本内容，支持颜色和字号调整
 entranceAssembly: "ConvenientText.dll"
 url: https://github.com/Tiny-Nick/ConvenientText
+version: 1.0.0.4
+apiVersion: 2.0.0.0
+author: Tiny-Nick
 repoOwner: Tiny-Nick
 repoName: ConvenientText
 assetsRoot: main/
-artifactName: ConvenientText.cipx
-tagPattern: *
-version: 1.0.0.3
-apiVersion: 2.0.0.0
-author: Tiny-Nick
-supportedOSPlatforms:
-- Windows

--- a/index/plugins-v2/ConvenientText.yml
+++ b/index/plugins-v2/ConvenientText.yml
@@ -1,0 +1,15 @@
+id: ConvenientText
+name: 便捷文本插件
+description: 桌面悬浮窗快速修改文本内容，支持颜色和字号调整
+entranceAssembly: "ConvenientText.dll"
+url: https://github.com/Tiny-Nick/ConvenientText
+repoOwner: Tiny-Nick
+repoName: ConvenientText
+assetsRoot: main/
+artifactName: ConvenientText.cipx
+tagPattern: *
+version: 1.0.0.3
+apiVersion: 2.0.0.0
+author: Tiny-Nick
+supportedOSPlatforms:
+- Windows


### PR DESCRIPTION
# ClassIsland 的快捷文本编辑插件

## 怎么用

- 装好插件后，在设置 → 组件里把「便捷文本」拖到主界面上
- 桌面上会出现一个灰色圆 ✎ 按钮，点一下弹出编辑框
- 改文字、选颜色、调字号，点确定，主界面立刻变

## 兼容性

- ClassIsland 2.1.0.0
- Windows 10 / 11

> Classisland 2.0.0.0 版本应该也是可以用的

> 理论上 Linux/macOS 也能跑，没测过，但是提交的 yml 中只标注了 Windows，所以Linux 和 MacOS 端的可能需要网盘手动下载

## 作者

BiliBili @Tiny 11 25H2

- 作者主页：https://space.bilibili.com/1274920807
- 宣传片： https://www.bilibili.com/video/BV1KhjH6JE7P/?share_source=copy_web&vd_source=762b42e92a3ba264404084a748e6e867
- 网盘下载：https://pan.baidu.com/s/1CBuayEWFDYlqeTEqV5oQ2A?pwd=ProN 提取码: ProN
- Github仓库：https://github.com/Tiny-Nick/ConvenientText
> 网盘版本可能滞后于 GitHub Release，建议优先使用 GitHub 渠道。

> 本插件代码由 AI （98%+）生成，如果遇到Bug欢迎去往宣传片视频评论区反馈，目前会保持支持维护。

# 更新日志

## 1.0.0.4

### 已修复

> 1.0.0.3版本安装不了

## 1.0.0.3

- 成功打包上传至 Github 仓库
- 仓库地址：https://github.com/Tiny-Nick/ConvenientText

### 修复问题

> 已正确显示版本号

### 已知问题

> 即使关闭文本编辑组件，桌面编辑按钮依旧会显示

### ~~严重问题~~

> ~~1.0.0.3本地安装会报错，马上推出1.0.0.4修复更改~~

> 已修复 

## 1.0.0.2

- 对“文本编辑”窗口的高度进行调整，使之看起来更加和谐
- 宣传片：【[Classisland2.X ]ConvenientText 一款更加便利宽松的文本编辑插件】 https://www.bilibili.com/video/BV1KhjH6JE7P/?share_source=copy_web&vd_source=762b42e92a3ba264404084a748e6e867
- 网盘下载方式：https://pan.baidu.com/s/1CBuayEWFDYlqeTEqV5oQ2A?pwd=ProN 提取码: ProN

### 已知问题:

> 多桌面上只会在其中一个桌面显示快捷入口 

> ~~有的时候桌面按钮会突然置顶~~（基本不影响使用，不会修复）

> 版本号显示有问题，仍显示1.0.0.1

## 1.0.0.1

### 修复问题

> 修正桌面按钮黑色矩形阴影边框的长宽大小

> 修正桌面按钮圆形图像内部大小填充

## 1.0.0.0

- 项目立项创建并基本完成

# 许可证

MIT License © Tiny-Nick
<img width="384" height="384" alt="icon" src="https://github.com/user-attachments/assets/9b452e14-a88e-4ad0-b367-5408019f841b" />
