### PR TITLE
iCalClassisland

### DIFF
--- a/index/plugins-v2/iCalClassIsland.yml
+++ b/index/plugins-v2/iCalClassIsland.yml
@@ -1,0 +1,11 @@
+id: iCalClassIsland
+name: iCal 日程
+description: 从 iCal 文件加载当天的日程并显示在主界面上，支持实时进度显示、多文件合并、时间冲突检测、日历视图。
+entranceAssembly: "iCalClassIsland.dll"
+url: https://github.com/wjj-8283/iCalClassIsland
+repoOwner: wjj-8283
+repoName: iCalClassIsland
+assetsRoot: main/
+version: 1.0.0.0
+apiVersion: 2.0.0.0
+author: wjj-8283


### PR DESCRIPTION
插件用途：读取ics日历文件，并且模仿ClassIsland本体的课程表组件加载
<img width="1680" height="1050" alt="Screenshot 2026-06-26 at 5 26 39 pm" src="https://github.com/user-attachments/assets/a4f30a31-5265-4de3-87f1-336ce93767a4" />
