### PR TITLE
添加插件classisland.schoolstats 到v2 plugin index

### DIFF
--- a/index/plugins-v2/classisland.schoolstats.yml
+++ b/index/plugins-v2/classisland.schoolstats.yml
@@ -1,0 +1,11 @@
+id: classisland.schoolstats
+name: 在校时间统计
+apiVersion: 2.1.0.1
+description: 统计学期内在校天数与时长，自动排除周末和法定节假日，并支持自定义寒暑假
+entranceAssembly: "ClassIsland.SchoolStats.dll"
+url: https://github.com/Chineseshuaji/ClassIsland-SchoolStats
+author: Chineseshuaji
+repoOwner: Chineseshuaji
+repoName: ClassIsland-SchoolStats
+assetsRoot: main
+artifactName: ClassIsland.SchoolStats.cipx


### PR DESCRIPTION
## 变更

- 将 `classisland.schoolstats` 添加到 ClassIsland 2.x 插件索引。
- 指定插件仓库、根目录及唯一发布附件 `ClassIsland.SchoolStats.cipx`。
- 插件要求 ClassIsland API `2.1.0.1` 或更高版本。

## 插件信息

- 仓库：https://github.com/Chineseshuaji/ClassIsland-SchoolStats
- Release：https://github.com/Chineseshuaji/ClassIsland-SchoolStats/releases/tag/0.1.0.0
- 许可证：MIT

## 验证

- 使用官方 `ClassIsland.PluginIndexGenerator 1.1.1.0` 执行完整验证，成功生成 `index.v2.json` 并返回 `OK!`。
- Release 为正式版本，标签符合四段版本格式。
- Release 仅包含一个 CIPX，正文 MD5 与附件实际校验值一致。
- `git diff --check` 通过；PR 仅新增一个索引清单文件。
