### PR TITLE
上架 MiniMax Speech TTS 插件

### DIFF
--- a/index/plugins-v2/ClassIsland.MiniMaxTts.yml
+++ b/index/plugins-v2/ClassIsland.MiniMaxTts.yml
@@ -1,0 +1,15 @@
+id: cn.classisland.minimax-tts
+name: MiniMax Speech TTS
+description: 将 MiniMax Speech 接入 ClassIsland，支持自定义模型、音色和持久化短语缓存。
+entranceAssembly: ClassIsland.MiniMaxTts.dll
+url: https://github.com/yijinyao0202/ClassIsland-MiniMaxTts
+version: 1.3.0.0
+apiVersion: 2.0.0.0
+author: yijinyao0202
+readme: README.md
+icon: icon.png
+repoOwner: yijinyao0202
+repoName: ClassIsland-MiniMaxTts
+assetsRoot: main
+artifactName: ClassIsland.MiniMaxTts.cipx
+supportedOSPlatforms: [Windows]


### PR DESCRIPTION
## 变更

- 上架 MiniMax Speech TTS 插件。
- 支持自定义 MiniMax 模型与音色。
- 支持自动短语分段、持久化缓存和跨播报短语复用。

## 发布信息

- 源码仓库：https://github.com/yijinyao0202/ClassIsland-MiniMaxTts
- Release：https://github.com/yijinyao0202/ClassIsland-MiniMaxTts/releases/tag/1.3.0.0
- 插件版本：`1.3.0.0`
- ClassIsland API：`2.0.0.0`

## 验证

- Release 工作流构建成功。
- Release 中已包含 `ClassIsland.MiniMaxTts.cipx`。
- 已验证 CIPX 包含入口 DLL、`manifest.yml`、README 和图标。
- 本地 Release 构建和短语缓存冒烟测试通过。
