### PR TITLE
更新 MiniMax TTS 至 1.3.0.2

### DIFF
--- a/index/plugins-v2/ClassIsland.MiniMaxTts.yml
+++ b/index/plugins-v2/ClassIsland.MiniMaxTts.yml
@@ -3,9 +3,9 @@ name: MiniMax Speech TTS
 description: 将 MiniMax Speech 接入 ClassIsland，支持自定义模型、音色和持久化短语缓存。
 entranceAssembly: ClassIsland.MiniMaxTts.dll
 url: https://github.com/yijinyao0202/ClassIsland-MiniMaxTts
-version: 1.3.0.1
+version: 1.3.0.2
 apiVersion: 2.0.0.0
-author: yijinyao0202
+author: 伊烬遥
 readme: README.md
 icon: icon.png
 repoOwner: yijinyao0202


### PR DESCRIPTION
更新 MiniMax Speech TTS 插件索引到 1.3.0.2。\n\n变更内容：\n- 作者显示名改为：伊烬遥。\n- 保留 1.3.0.1 的新版插件图标。\n- Release 包已包含 ClassIsland 要求的 MD5 注释和 AI 生成声明。\n\nRelease: https://github.com/yijinyao0202/ClassIsland-MiniMaxTts/releases/tag/1.3.0.2\nMD5: 8d90988e696b42a74e9919a26bbd8fdb