### PR TITLE
feat: add SecAgent ClassIsland plugin

### DIFF
--- a/index/plugins-v2/classisland.secagent.yml
+++ b/index/plugins-v2/classisland.secagent.yml
@@ -1,0 +1,17 @@
+id: classisland.secagent
+name: SecAgent 联动插件
+description: ClassIsland 与 SecAgent 联动插件，为 SecAgent 提供 ClassIsland 服务和课程安排查询工具。
+entranceAssembly: "ClassIsland.SecAgent.Plugin.dll"
+url: https://github.com/SECTL/ClassIsland-SecAgent-Plugin
+version: 0.1.0.0
+apiVersion: 2.0.0.0
+author: SECTL
+readme: README.md
+icon: icon.svg
+repoOwner: SECTL
+repoName: ClassIsland-SecAgent-Plugin
+assetsRoot: main/
+artifactName: ClassIsland.SecAgent.Plugin.cipx
+supportedOSPlatforms:
+  - Windows
+  - OSX

--- a/index/plugins-v2/inkcanvas.iccce.secagent.yml
+++ b/index/plugins-v2/inkcanvas.iccce.secagent.yml
@@ -1,0 +1,15 @@
+id: inkcanvas.iccce.secagent
+name: ICC-CE SecAgent HTTP Plugin
+description: ICC-CE 与 SecAgent 联动插件，为 SecAgent 提供 ICC-CE HTTP 服务，并自动请求安装 SecAgent Connector。
+entranceAssembly: "ICC-CE.SecAgent.Plugin.dll"
+url: https://github.com/SECTL/ICC-CE-SecAgent-Plugin
+version: 0.2.0
+apiVersion: 1.0.0
+author: SECTL
+readme: README.md
+repoOwner: SECTL
+repoName: ICC-CE-SecAgent-Plugin
+assetsRoot: main/
+artifactName: inkcanvas.iccce.secagent.icpx
+supportedOSPlatforms:
+  - Windows


### PR DESCRIPTION
## 新增了SecAgent联动插件

- Add the SecAgent ClassIsland integration plugin to the ClassIsland 2.x plugin index.
- Plugin repository: https://github.com/SECTL/ClassIsland-SecAgent-Plugin
- Release: https://github.com/SECTL/ClassIsland-SecAgent-Plugin/releases/tag/0.1.0.0
- The referenced release uses the required four-part tag 