### PR TITLE
Create Flight.classisland.lanbroadcast.yml

### DIFF
--- a/index/plugins-v2/Flight.classisland.lanbroadcast.yml
+++ b/index/plugins-v2/Flight.classisland.lanbroadcast.yml
@@ -7,7 +7,7 @@ repoOwner: HanXiMC
 repoName: CLassisland_broadcast
 assetsRoot: master/
 artifactName: MyPlugin.cipx
-version: 1.0.0.0
+version: 2.0.0.0
 apiVersion: 2.0.0.0
 author: Flight
 icon: icon.png

--- a/index/plugins-v2/Flight.classisland.lanbroadcast.yml
+++ b/index/plugins-v2/Flight.classisland.lanbroadcast.yml
@@ -5,7 +5,7 @@ entranceAssembly: MyPlugin.dll
 url: https://github.com/HanXiMC/CLassisland_broadcast
 repoOwner: HanXiMC
 repoName: CLassisland_broadcast
-assetsRoot: master/
+assetsRoot: main/
 artifactName: MyPlugin.cipx
 version: 2.0.0.0
 apiVersion: 2.0.0.0

--- a/index/plugins-v2/Flight.classisland.lanbroadcast.yml
+++ b/index/plugins-v2/Flight.classisland.lanbroadcast.yml
@@ -1,0 +1,15 @@
+id: Flight.classisland.lanbroadcast
+name: 局域网广播通知
+description: 允许通过局域网 Web 页面向 ClassIsland 显示栏发送并持久化广播消息。
+entranceAssembly: MyPlugin.dll
+url: https://github.com/HanXiMC/CLassisland_broadcast
+repoOwner: HanXiMC
+repoName: CLassisland_broadcast
+assetsRoot: master/
+artifactName: MyPlugin.cipx
+version: 1.0.0.0
+apiVersion: 2.0.0.0
+author: Flight
+icon: icon.png
+supportedOSPlatforms:
+  - Windows


### PR DESCRIPTION
申请上架新插件。

* 插件名称：局域网广播通知
* 插件 ID：Flight.classisland.lanbroadcast
* 提交版本：1.0.0.0
* 功能简介：允许通过局域网 Web 页面向 ClassIsland 显示栏发送并持久化广播消息。