### PR TITLE
添加 ClassGuard 离班助手

### DIFF
--- a/index/plugins-v2/ClassGuard.yml
+++ b/index/plugins-v2/ClassGuard.yml
@@ -1,0 +1,16 @@
+id: ClassGuard
+name: ClassGuard 离班助手
+description: 下课一段时间后，将自动检查 USB 设备是否已弹出，以及指定软件是否仍在运行，避免教师离开教室前有所遗漏。
+entranceAssembly: ClassGuard.dll
+url: https://github.com/sky-shunfengjun/ClassGuard
+version: 1.0.1.0
+apiVersion: 2.1.0.1
+author: sky-shunfengjun
+readme: README.md
+icon: icon.png
+repoOwner: sky-shunfengjun
+repoName: ClassGuard
+assetsRoot: main
+artifactName: ClassGuard.cipx
+supportedOSPlatforms:
+  - Windows


### PR DESCRIPTION
## 插件信息

- 插件名称：ClassGuard 离班助手
- 插件版本：1.0.1.0
- 支持平台：Windows
- 最低 API 版本：2.1.0.1
- 源码仓库：https://github.com/sky-shunfengjun/ClassGuard
- 发布页面：https://github.com/sky-shunfengjun/ClassGuard/releases/tag/1.0.1.0

## 功能简介

ClassGuard 会在下课或放学后等待设定时间，再检查 USB 设备是否仍未安全弹出，以及内置或用户自定义的软件进程是否仍在运行，并通过 ClassIsland 提醒教师离开教室前进行处理。插件支持课程排除、两种提醒时机、延时期间取消和多项目合并提醒。

## 发布检查

- 62 项自动化测试全部通过。
- 主项目和测试项目均未发现已知依赖漏洞。
- Release 构建为 0 警告、0 错误。
- `ClassGuard.cipx` 已上传到 `1.0.1.0` Release。
- 安装包 MD5：`E82F9A5260A3C1A2EEA250C5BD18DFC3`。
- 安装包 SHA-256：`6997104077BE2F83EDF0A3F8ABDA0780863F338069C798F4BC051BACDE140B81`。
