### PR TITLE
add: GameIsland 小游戏合集

### DIFF
--- a/index/plugins-v2/GameIsland.yml
+++ b/index/plugins-v2/GameIsland.yml
@@ -1,6 +1,6 @@
 id: GameIsland
 name: GameIsland 小游戏合集
-version: 1.0.0.0
+version: 1.0.0.1
 author: yty16
 description: 46 款经典小游戏合集（棋牌、益智、动作、休闲），悬浮窗运行，支持键鼠/触控、中英双语、背景配乐与游戏音效。
 apiVersion: 2.0.0.0

--- a/index/plugins-v2/GameIsland.yml
+++ b/index/plugins-v2/GameIsland.yml
@@ -1,0 +1,15 @@
+id: GameIsland
+name: GameIsland 小游戏合集
+version: 1.0.0.0
+author: yty16
+description: 46 款经典小游戏合集（棋牌、益智、动作、休闲），悬浮窗运行，支持键鼠/触控、中英双语、背景配乐与游戏音效。
+apiVersion: 2.0.0.0
+entranceAssembly: "GameIsland.dll"
+icon: icon.png
+readme: README.md
+url: https://github.com/yty16/GameIsland
+repoOwner: yty16
+repoName: GameIsland
+assetsRoot: main
+artifactName: GameIsland.cipx
+supportedOSPlatforms: [Windows]

--- a/index/plugins-v2/GameIsland.yml
+++ b/index/plugins-v2/GameIsland.yml
@@ -1,6 +1,6 @@
 id: GameIsland
 name: GameIsland 小游戏合集
-version: 1.0.0.1
+version: 1.0.0.2
 author: yty16
 description: 46 款经典小游戏合集（棋牌、益智、动作、休闲），悬浮窗运行，支持键鼠/触控、中英双语、背景配乐与游戏音效。
 apiVersion: 2.0.0.0


### PR DESCRIPTION
添加 GameIsland 插件清单（面向 ClassIsland 2.x）。

- id: GameIsland
- 46 款小游戏合集，悬浮窗运行，支持键鼠/触控、中英双语、背景配乐与游戏音效
- apiVersion: 2.0.0.0，entranceAssembly: GameIsland.dll
- Release 资产：GameIsland.cipx（tag 1.0.0.0）