### PR TITLE
添加NoDutyToday值日表插件

### DIFF
--- a/index/plugins-v2/NoDutyToday.yml
+++ b/index/plugins-v2/NoDutyToday.yml
@@ -1,0 +1,14 @@
+id: NoDutyToday
+name: NoDutyToday
+description: 一个不会用DutyIsland的屑vibecoding实现的值日表。
+url: https://github.com/Tb114/NoDutyToday
+repoOwner: Tb114
+repoName: NoDutyToday
+entranceAssembly: "NoDutyToday.dll"
+assetsRoot: main
+artifactName: NoDutyToday.cipx
+version: 0.0.1.0
+apiVersion: 2.0.0.0
+author: Tb
+supportedOSPlatforms:
+- Windows

--- a/index/plugins-v2/NoDutyToday.yml
+++ b/index/plugins-v2/NoDutyToday.yml
@@ -7,7 +7,6 @@ repoName: NoDutyToday
 entranceAssembly: "NoDutyToday.dll"
 assetsRoot: main
 artifactName: NoDutyToday.cipx
-version: 0.0.1.0
 apiVersion: 2.0.0.0
 author: Tb
 supportedOSPlatforms:


### PR DESCRIPTION
## 申请添加NoDutyToday值日表插件
~不过也不重要，反正就我自己用，别人大概是不会用的~
  
  
```yaml
id: NoDutyToday
name: NoDutyToday
description: 一个不会用DutyIsland的屑vibecoding实现的值日表。
url: https://github.com/Tb114/NoDutyToday
repoOwner: Tb114
repoName: NoDutyToday
entranceAssembly: "NoDutyToday.dll"
assetsRoot: main
artifactName: NoDutyToday.cipx
apiVersion: 2.0.0.0
author: Tb
supportedOSPlatforms:
- Windows
```