### PR TITLE
添加 像素流动、随机抽选、值日提醒、课后自动复原 插件

### DIFF
--- a/index/plugins-v2/gordon.classreset.yml
+++ b/index/plugins-v2/gordon.classreset.yml
@@ -1,0 +1,10 @@
+id: gordon.classreset
+name: 课后自动复原
+description: 下课后自动把电脑恢复原状：关闭学生开的程序、弹出 U 盘、清理桌面。执行前全屏倒计时，点击屏幕即取消；支持按科目定制与定时关机。
+entranceAssembly: "ClassIsland.ClassReset.dll"
+url: https://github.com/Gordonynh/ClassReset
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: ClassReset
+assetsRoot: main

--- a/index/plugins-v2/gordon.dutyroster.yml
+++ b/index/plugins-v2/gordon.dutyroster.yml
@@ -1,0 +1,10 @@
+id: gordon.dutyroster
+name: 值日提醒
+description: 到点主动弹出值日安排，人名用大字显示，超时自动关闭。日常时间点用卡片，大扫除整屏提醒。值日表为纯文本，一行一个时间点。
+entranceAssembly: "ClassIsland.DutyRoster.dll"
+url: https://github.com/Gordonynh/DutyRoster
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: DutyRoster
+assetsRoot: main

--- a/index/plugins-v2/gordon.randompicker.yml
+++ b/index/plugins-v2/gordon.randompicker.yml
@@ -1,0 +1,10 @@
+id: gordon.randompicker
+name: 随机抽选
+description: 桌面抽人悬浮窗。点击抽取名单中的一人，屏幕中央弹出大字；支持拍照抽人，从合影中检测人脸随机抽取。名单为纯文本，一行一个名字。
+entranceAssembly: "ClassIsland.RandomPicker.dll"
+url: https://github.com/Gordonynh/RandomPicker
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: RandomPicker
+assetsRoot: main

--- a/index/plugins-v2/gordon.ultracode.yml
+++ b/index/plugins-v2/gordon.ultracode.yml
@@ -1,0 +1,10 @@
+id: gordon.ultracode
+name: 像素流动
+description: 仿 Claude Code UltraCode 的像素流动动画，替换提醒的遮罩层与正文层背景。配色跟随应用主题色，倒计时以彩带长度表示剩余时间。
+entranceAssembly: "ClassIsland.UltraCode.dll"
+url: https://github.com/Gordonynh/PixelFlow
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: PixelFlow
+assetsRoot: main


### PR DESCRIPTION
新增四个插件，均已在各自仓库发布 1.0.0.0 release（含 .cipx 与 MD5）：

- **像素流动**（gordon.ultracode）：仿 Claude Code UltraCode 的提醒背景动画 — https://github.com/Gordonynh/PixelFlow
- **随机抽选**（gordon.randompicker）：抽人悬浮窗，支持拍照抽人（YuNet + ONNX Runtime 随包）— https://github.com/Gordonynh/RandomPicker
- **值日提醒**（gordon.dutyroster）：到点弹出值日安排，大扫除整屏提醒 — https://github.com/Gordonynh/DutyRoster
- **课后自动复原**（gordon.classreset）：下课后自动关程序、弹 U 盘、清理桌面，可定时关机 — https://github.com/Gordonynh/ClassReset

均为 MIT 协议，针对 ClassIsland 2.1（Avalonia）构建。