### PR TITLE
添加插件 GlycoLinker

### DIFF
--- a/index/plugins-v2/ink.lipoly.ext.glycoLinker.yml
+++ b/index/plugins-v2/ink.lipoly.ext.glycoLinker.yml
@@ -1,0 +1,12 @@
+# nonk8s
+id: ink.lipoly.ext.glycoLinker
+name: GlycoLinker.Island
+description: Glycoprotein协议支持
+entranceAssembly: "GlycoLinker.Island.dll"
+url: https://github.com/LiPolymer/GlycoLinker.Island
+version: 0.0.1.0
+apiVersion: 2.1.1.1
+author: LiPolymer
+repoOwner: LiPolymer
+repoName: GlycoLinker.Island
+assetsRoot: main/GlycoLinker.Island


### PR DESCRIPTION
[GlycoLinker](https://github.com/LiPolymer/GlycoLinker.Island) 是一个将 [ClassIsland](https://classisland.tech/) 接入 [Glycoprotein](https://gitlab.com/LiPolymer/Glycoprotein) ([Github](https://github.com/LiPolymer/Glycoprotein)) 节点网络的插件, 让 ClassIsland 的自动化能力可以与外部节点双向联动。

本插件以 AGPLv3 协议获得许可

核心协议库以 LGPLv3 获得许可

感谢您的审核😋