### PR TITLE
添加RemoteCI插件

### DIFF
--- a/index/plugins-v2/remoteci.plugin.yml
+++ b/index/plugins-v2/remoteci.plugin.yml
@@ -1,0 +1,17 @@
+id: remoteci.plugin
+name: RemoteCI
+description: 用于接入 RemoteCI 服务端，支持在WearOS手表App上执行换课、通知、主界面显示隐藏、音量、电源及扩展控制。
+entranceAssembly: "RemoteCI.Plugin.dll"
+icon: icon.png
+readme: README.md
+url: https://github.com/MEMZ-Edge01/RemoteCI
+version: 3.2.1.2
+apiVersion: 2.0.0.0
+author: MEMZ-Edge01
+repoOwner: MEMZ-Edge01
+repoName: RemoteCI
+assetsRoot: main/plugin/RemoteCI.Plugin
+artifactName: RemoteCI.Plugin.cipx
+tagPattern: "3.*.*.*"
+supportedOSPlatforms:
+  - Windows


### PR DESCRIPTION
# 添加插件RemoteCI
## 插件功能
该插件用于接入 RemoteCI 服务端，支持在WearOS手表App上执行换课、通知、主界面显示隐藏、音量、电源及更多扩展控制。
## 项目仓库
[MEMZ-Edge01/RemoteCI](https://github.com/MEMZ-Edge01/RemoteCI)
## 效果

<img width="2990" height="1374" alt="371bfdf0102d662bc1e8d97a0f47c7f5" src="https://github.com/user-attachments/assets/58b66111-970c-4a16-908c-8760a64f2e56" />
<img width="2513" height="962" alt="d7f7b17b79470326515bd665711a9b33" src="https://github.com/user-attachments/assets/0e6e765c-fb6c-4817-bf1f-25894c8c9900" />
<img width="3108" height="1353" alt="1f78e12d71c4cbb3084db0afe862a974" src="https://github.com/user-attachments/assets/ab2fafdd-9a60-4e64-bcc2-f940a1ae5607" />
