### PR TITLE
添加 桌面小组件、液态玻璃 插件

### DIFF
--- a/index/plugins-v2/gordon.desktopwidgets.yml
+++ b/index/plugins-v2/gordon.desktopwidgets.yml
@@ -1,0 +1,10 @@
+id: gordon.desktopwidgets
+name: 桌面小组件
+description: 苹果桌面小组件那一套，搬到 Windows 上给教室大屏用。自带时钟、课程表、天气、雨云图、值日、倒计时、便签等 15 个小组件；默认压在所有窗口之下，回到桌面才看得见。
+entranceAssembly: "ClassIsland.DesktopWidgets.dll"
+url: https://github.com/Gordonynh/DesktopWidgets
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: DesktopWidgets
+assetsRoot: main

--- a/index/plugins-v2/gordon.liquidglass.yml
+++ b/index/plugins-v2/gordon.liquidglass.yml
@@ -1,0 +1,10 @@
+id: gordon.liquidglass
+name: 液态玻璃
+description: 把状态栏换成苹果液态玻璃质感，折射背后实际显示的内容，而不是简单加一层半透明。
+entranceAssembly: "ClassIsland.LiquidGlass.dll"
+url: https://github.com/Gordonynh/LiquidGlass
+apiVersion: 2.0.0.0
+author: GordonYoung
+repoOwner: Gordonynh
+repoName: LiquidGlass
+assetsRoot: main


### PR DESCRIPTION
添加两个插件，都是给中学教室大屏用的。

| 插件 | ID | 仓库 |
|---|---|---|
| 桌面小组件 | `gordon.desktopwidgets` | https://github.com/Gordonynh/DesktopWidgets |
| 液态玻璃 | `gordon.liquidglass` | https://github.com/Gordonynh/LiquidGlass |

**桌面小组件**：苹果桌面小组件那一套搬到 Windows。自带时钟、课程表、天气、雨云图、值日、
倒计时、便签、日历、待办、世界时钟、正在播放、照片、快捷启动、计算器、系统状态共 15 个。
默认压在所有窗口之下、回到桌面才看得见，不遮挡全屏课件；用别的程序时自动褪成单色。

**液态玻璃**：把状态栏换成苹果液态玻璃质感，折射背后实际显示的内容，而不是简单加一层半透明。

两者均已发布 1.0.0.0，附带 `.cipx` 与 MD5，MIT 协议，仅 Windows，apiVersion 2.0.0.0。

同一作者此前的四个插件（#172）已同步更新到 1.1.0.0，索引条目无需改动。
