### PR TITLE
添加插件：Classcaller（课堂点名器）、IslandManger集控接收端

### DIFF
--- a/index/plugins-v2/Classcaller
+++ b/index/plugins-v2/Classcaller
@@ -1,0 +1,16 @@
+id: Classcaller
+name: Classcaller
+description: 一个基于 ClassIsland 的轻量级点名器（独立维护，支持自定义与密码保护）
+entranceAssembly: "Classcaller.dll"
+url: https://github.com/1sIancl/IslandCallerTopmostEnhancer
+author: 1sIancl
+version: 1.2.1.0
+apiVersion: 2.1.1.1
+icon: icon.png
+supportedOSPlatforms:
+  - Windows
+repoOwner: 1sIancl
+repoName: IslandCallerTopmostEnhancer
+assetsRoot: main
+artifactName: Classcaller.cipx
+tagPattern: "1.*.*.*"

--- a/index/plugins-v2/Classcaller
+++ b/index/plugins-v2/Classcaller
@@ -2,7 +2,7 @@ id: Classcaller
 name: Classcaller
 description: 一个基于 ClassIsland 的轻量级点名器（独立维护，支持自定义与密码保护）
 entranceAssembly: "Classcaller.dll"
-url: https://github.com/1sIancl/IslandCallerTopmostEnhancer
+url: https://github.com/1sIancl/Classcaller
 author: 1sIancl
 version: 1.2.1.0
 apiVersion: 2.1.1.1
@@ -10,7 +10,7 @@ icon: icon.png
 supportedOSPlatforms:
   - Windows
 repoOwner: 1sIancl
-repoName: IslandCallerTopmostEnhancer
+repoName: Classcaller
 assetsRoot: main
 artifactName: Classcaller.cipx
 tagPattern: "1.*.*.*"

--- a/index/plugins-v2/Classcaller
+++ b/index/plugins-v2/Classcaller
@@ -4,7 +4,7 @@ description: 一个基于 ClassIsland 的轻量级点名器（独立维护，支
 entranceAssembly: "Classcaller.dll"
 url: https://github.com/1sIancl/Classcaller
 author: 1sIancl
-version: 1.2.2.0
+version: 1.2.2.1
 apiVersion: 2.1.1.1
 icon: icon.png
 supportedOSPlatforms:

--- a/index/plugins-v2/Classcaller
+++ b/index/plugins-v2/Classcaller
@@ -4,7 +4,7 @@ description: 一个基于 ClassIsland 的轻量级点名器（独立维护，支
 entranceAssembly: "Classcaller.dll"
 url: https://github.com/1sIancl/Classcaller
 author: 1sIancl
-version: 1.2.1.0
+version: 1.2.2.0
 apiVersion: 2.1.1.1
 icon: icon.png
 supportedOSPlatforms:


### PR DESCRIPTION
本 PR 上架两个插件：

1. **Classcaller（课堂点名器）** —— 公平随机点名、防重复均衡、悬浮窗、多档案、TTS 播报。
2. **IslandManger集控接收端** —— 接入 IslandManger 集控服务器，自动接收课表/时间表/科目/自定义设置下发。

IslandManger集控接收端信息：
- 仓库：https://github.com/1sIancl/IslandManger
- 入口程序集：ControlHub.Plugin.dll
- 版本：1.0.0.0（Release tag `1.0.0.0` 已含 MD5 校验）
- 支持平台：Windows / Linux / macOS