### PR TITLE
申请添加主题：FoggyGlass

### DIFF
--- a/index/themes/dev.maxsui.foggyglass.yml
+++ b/index/themes/dev.maxsui.foggyglass.yml
@@ -2,7 +2,7 @@ id: dev.maxsui.foggyglass
 name: FoggyGlass
 description: 受 Aqua 及 Aero 设计语言启发的模糊玻璃主题。
 url: https://github.com/Suixiuliang/ClassIsland-Theme-FoggyGlass
-author: MaxSui(使用前请阅读ReadMe)
+author: MaxSui
 version: 1.0.0.0
 repoOwner: Suixiuliang
 repoName: ClassIsland-Theme-FoggyGlass

--- a/index/themes/dev.maxsui.foggyglass.yml
+++ b/index/themes/dev.maxsui.foggyglass.yml
@@ -2,9 +2,9 @@ id: dev.maxsui.foggyglass
 name: FoggyGlass
 description: 受 Aqua 及 Aero 设计语言启发的模糊玻璃主题。
 url: https://github.com/Suixiuliang/ClassIsland-Theme-FoggyGlass
-author: MaxSui
+author: MaxSui(使用前请阅读ReadMe)
 version: 1.0.0.0
-repoOwner: MaxSui(使用前请先仔细阅读仓库README!)
+repoOwner: Suixiuliang
 repoName: ClassIsland-Theme-FoggyGlass
 assetsRoot: main/dev.maxsui.foggyglass
 artifactName: FoggyGlass.zip

--- a/index/themes/dev.maxsui.foggyglass.yml
+++ b/index/themes/dev.maxsui.foggyglass.yml
@@ -1,0 +1,11 @@
+id: dev.maxsui.foggyglass
+name: FoggyGlass
+description: 受 Aqua 及 Aero 设计语言启发的模糊玻璃主题。
+url: https://github.com/Suixiuliang/ClassIsland-Theme-FoggyGlass
+author: MaxSui
+version: 1.0.0.0
+repoOwner: MaxSui(使用前请先仔细阅读仓库README!)
+repoName: ClassIsland-Theme-FoggyGlass
+assetsRoot: main/dev.maxsui.foggyglass
+artifactName: FoggyGlass.zip
+banner: banner.png

--- a/index/themes/dev.maxsui.foggyglass.yml
+++ b/index/themes/dev.maxsui.foggyglass.yml
@@ -4,7 +4,7 @@ description: 受 Aqua 及 Aero 设计语言启发的模糊玻璃主题。
 url: https://github.com/Suixiuliang/ClassIsland-Theme-FoggyGlass
 author: MaxSui
 version: 1.0.0.0
-repoOwner: Suixiuliang
+repoOwner: MaxSui
 repoName: ClassIsland-Theme-FoggyGlass
 assetsRoot: main/dev.maxsui.foggyglass
 artifactName: FoggyGlass.zip


### PR DESCRIPTION
Foggy Glass 主题 By MaxSui隋某人

## 预览
<img width="894" height="143" alt="屏幕截图 2026-09-09 131517" src="https://github.com/user-attachments/assets/93dde052-04ea-46fd-abb9-4ff1e1a14008" />

## 主题概述
- 优雅永不过时：浅色背景下从上到下的由深到浅的渐变,再加上玻璃的通透感······深色背景下,直接与背景融为一体,但是还能看见边框,完全不遮挡东西
-  不遮挡课件 ：CI 有一个很严重的通病,就是上课的时候如果不设置隐藏规则的话会遮挡课件；但是如果设置隐藏规则的话,有些同学又嚷嚷着要看距离下课还有多少分钟（真是左右为男啊...... 这一主题凭借着极致的通透,可以做到在牺牲课表的一定清晰度的前体下不遮挡课件,以课件为主；希沃白板的话直接在上面隐身,与白板融为一体......

希望可以收录